### PR TITLE
errors: kbdintrrpt, ioerr, pipe, unicode

### DIFF
--- a/lolcat
+++ b/lolcat
@@ -13,8 +13,12 @@ import random
 import re
 import sys
 import time
+from signal import signal, SIGPIPE, SIG_DFL
 
 PY3 = sys.version_info >= (3,)
+
+# override default handler so no exceptions on SIGPIPE
+signal(SIGPIPE, SIG_DFL)
 
 # Reset terminal colors at exit
 def reset():
@@ -185,14 +189,18 @@ def run():
         args = ['-']
 
     for filename in args:
-        if filename == '-':
-            lolcat.cat(sys.stdin, options)
-        else:
-            try:
-                with open(filename, 'r') as handle:
+        try:
+            if filename == '-':
+                lolcat.cat(sys.stdin, options)
+            else:
+                with open(filename, 'r', errors='backslashreplace') as handle:
                     lolcat.cat(handle, options)
-            except IOError as error:
-                sys.stderr.write(str(error) + '\n')
+        except IOError as error:
+            sys.stderr.write(str(error) + '\n')
+        except KeyboardInterrupt:
+            sys.stderr.write('\n')
+            # exit 130 for terminated-by-ctrl-c, from http://tldp.org/LDP/abs/html/exitcodes.html
+            return 130
 
 if __name__ == '__main__':
     sys.exit(run())


### PR DESCRIPTION
* override default SIGPIPE handler to not throw exceptions
* try/catch around all file handling not just open
* quell traceback on KeyboardInterrupt & IOError
* encoding error strategy: use 'backslashreplace' to avoid
  UnicodeDecodeError when opening binary files
  FIXME: needs a more sophisticated solution to handle text
         with encodings other than our detected default, but
         this method should provide (ugly) output without
         spewing traceback all over the user